### PR TITLE
Avoid crashing on certain unknown CSS properties

### DIFF
--- a/lib/css-flip.js
+++ b/lib/css-flip.js
@@ -115,7 +115,7 @@ function flipDeclarations(declarations) {
  * @return {String}
  */
 function flipProperty(property) {
-  return PROPERTIES[property] || property;
+  return PROPERTIES.hasOwnProperty(property) ? PROPERTIES[property] : property;
 }
 
 /**
@@ -126,7 +126,7 @@ function flipProperty(property) {
  * @return {String}
  */
 function flipValue(property, value) {
-  var flipFn = VALUES[property];
+  var flipFn = VALUES.hasOwnProperty(property) ? VALUES[property] : false;
 
   if (!flipFn) { return value; }
 

--- a/test/css-flip.test.js
+++ b/test/css-flip.test.js
@@ -300,6 +300,12 @@ describe('lettercase', function () {
   });
 });
 
+describe('invalid CSS', function () {
+  it('should not crash', function () {
+    ensure('p{__proto__:42;toString:lolwat;}', 'p{__proto__:42;tostring:lolwat;}');
+  });
+});
+
 describe('rework', function () {
   var reworkFlip = flip.rework();
   var css = require('css');


### PR DESCRIPTION
CSS like the following:

``` css
p {
  __proto__: 42;
  toString: lolwat;
}
```

…causes css-flip to crash. While these example properties are invalid in CSS, in general it would be better to just make css-flip preserve any unrecognized properties.

This patch avoids the crash.
