### PR TITLE
Support precise property-value replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Yields:
 
 ```css
 p {
-  /*@noflip*/ float: left;
+  float: left;
   clear: right;
 }
 ```
@@ -105,10 +105,33 @@ p {
 Yields:
 
 ```css
-/*@noflip*/
 p {
   float: left;
   clear: left;
+}
+```
+
+### @replace
+
+Replace the value of a single declaration. Useful for custom LTR/RTL
+adjustments, e.g., changing background sprite positions or the using a
+different glyph in an icon font.
+
+Source:
+
+```css
+p {
+  /*@replace: -32px -32px*/ background-position: -32px 0;
+  /*@replace: ">"*/ content: "<";
+}
+```
+
+Yields:
+
+```css
+p {
+  background-position: -32px -32px;
+  content: ">";
 }
 ```
 

--- a/test/css-flip.test.js
+++ b/test/css-flip.test.js
@@ -280,6 +280,14 @@ describe('@noflip', function () {
   });
 });
 
+describe('@replace', function () {
+  it('should replace individual declaration value', function () {
+    ensure('p{/*@replace:-30px 0*/background-position:0 0;}', 'p{background-position:-30px 0;}');
+    ensure('p{/*@replace:linear-gradient(to right, blue, green)*/background:linear-gradient(to left, blue, green);}', 'p{background:linear-gradient(to right, blue, green);}');
+    ensure('p{/*@replace:"<°"*/content:">°";}', 'p{content:"<°";}');
+  });
+});
+
 describe('nested blocks', function () {
   it('should be flipped', function () {
     ensure('@keyframes foo{from{float:left;}to{float:right;}}',


### PR DESCRIPTION
Went with `@replace` for the purposes of a POC.

cc @brettstimmerman
