### PR TITLE
Don't mutate property name lettercase

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 # css-flip history
 
+- Don't modify names of unflipped properties.
 - Add `@replace` directive to perform a precise value substitution.
 
 ## 0.3.0 - 24 Feb 2014

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function isFlippable(node, prevNode) {
  * Return whether the given `node` is replaceable.
  *
  * @param {Object} node
- * @param {Object} prevNode used for @noflip detection
+ * @param {Object} prevNode used for @replace detection
  * @returns {Boolean}
  */
 
@@ -118,33 +118,6 @@ function isReplaceable(node, prevNode) {
   }
 
   return false;
-}
-
-/**
- * BiDi flip the given `declaration`.
- *
- * @param {Object} declaration
- */
-
-function flipDeclaration(declaration) {
-  var name = (declaration.property || declaration.name).toLowerCase();
-
-  declaration.property = flipProperty(name);
-  declaration.value = flipValue(name, declaration.value);
-
-  return declaration;
-}
-
-/**
- * Replace the given `declaration` value.
- *
- * @param {Object} declaration
- */
-
-function replaceDeclaration(declaration, prevNode) {
-  declaration.value = prevNode.comment.match(RE_REPLACE)[1];
-
-  return declaration;
 }
 
 /**
@@ -170,25 +143,57 @@ function processDeclarations(declarations) {
 }
 
 /**
- * BiDi flip the given `property`.
+ * Replace the given `declaration` value.
  *
- * @param {String} property
- * @return {String}
+ * @param {Object} declaration
  */
 
-function flipProperty(property) {
-  return PROPERTIES.hasOwnProperty(property) ? PROPERTIES[property] : property;
+function replaceDeclaration(declaration, prevNode) {
+  declaration.value = prevNode.comment.match(RE_REPLACE)[1];
+
+  return declaration;
 }
 
 /**
- * BiDi flip the given `value`.
+ * BiDi flip the given `declaration`.
  *
- * @param {String} property
- * @param {String} value
+ * @param {Object} declaration
+ */
+
+function flipDeclaration(declaration) {
+  declaration = flipDeclarationProperty(declaration);
+  declaration = flipDeclarationValue(declaration);
+
+  return declaration;
+}
+
+/**
+ * BiDi flip the property of the given `declaration`.
+ *
+ * @param {String} declaration
  * @return {String}
  */
 
-function flipValue(property, value) {
+function flipDeclarationProperty(declaration) {
+  var property = declaration.property;
+  var normalizedProperty = property.toLowerCase();
+
+  declaration.property = PROPERTIES.hasOwnProperty(normalizedProperty) ? PROPERTIES[normalizedProperty] : property;
+
+  return declaration;
+}
+
+/**
+ * BiDi flip the value of the given `declaration`.
+ *
+ * @param {String} declaration
+ * @return {String}
+ */
+
+function flipDeclarationValue(declaration) {
+  var property = declaration.property;
+  var value = declaration.value;
+
   var flipFn = VALUES.hasOwnProperty(property) ? VALUES[property] : false;
 
   if (!flipFn) { return value; }
@@ -200,7 +205,9 @@ function flipValue(property, value) {
     newValue += important[0];
   }
 
-  return newValue;
+  declaration.value = newValue;
+
+  return declaration;
 }
 
 // -- Replacement Maps ---------------------------------------------------------

--- a/test/css-flip.test.js
+++ b/test/css-flip.test.js
@@ -299,18 +299,22 @@ describe('nested blocks', function () {
 });
 
 describe('lettercase', function () {
-  it('should downcase property names', function () {
+  it('should not lowercase property names that have not been flipped', function () {
+    ensure(':root{--Custom-prop:red;}', ':root{--Custom-prop:red;}');
+  });
+
+  it('should lowercase property names that have been flipped', function () {
     ensure('p{BORDER-LEFT:1px;}', 'p{border-right:1px;}');
   });
 
-  it('should not downcase property values', function () {
-    ensure('p{BORDER-LEFT:1PX;}', 'p{border-right:1PX;}');
+  it('should not lowercase property values', function () {
+    ensure('p{border-left:1PX;}', 'p{border-right:1PX;}');
   });
 });
 
 describe('invalid CSS', function () {
   it('should not crash', function () {
-    ensure('p{__proto__:42;toString:lolwat;}', 'p{__proto__:42;tostring:lolwat;}');
+    ensure('p{__proto__:42;toString:lolwat;}', 'p{__proto__:42;toString:lolwat;}');
   });
 });
 


### PR DESCRIPTION
Preserve the case of any properties that are not flipped. This ensures the script don't affect custom properties.

I also reordered some functions, which has contributed to the strange diff. And changed the `flipProperty` and `flipValue` functions to both take the full declaration as their only argument.

cc @brettstimmerman 

Fix gh-14
