### PR TITLE
Stricter left/right value flipping

### DIFF
--- a/lib/left-right.js
+++ b/lib/left-right.js
@@ -1,10 +1,10 @@
 /**
- * Flip a `"left"` or `"right"` value.
+ * Flip a `left` or `right` value.
  *
  * @param {String} value Value
  * @return {String}
  */
 
 module.exports = function (value) {
-  return value.match(/left/) ? 'right' : value.match(/right/) ? 'left' : value;
+  return value.match(/^\s*left\s*$/) ? 'right' : value.match(/^\s*right\s*$/) ? 'left' : value;
 };


### PR DESCRIPTION
Only flip exact `left` and `right` values. This prevents accidental
matches against those strings in custom properties.
